### PR TITLE
Update id_dataset requirement and add Martinet noir

### DIFF
--- a/nichoirs/site.json
+++ b/nichoirs/site.json
@@ -61,7 +61,7 @@
       "type_widget": "dataset",
       "attribut_label": "Jeu de données",
       "type_util": "dataset",
-      "required": false,
+      "required": true,
       "module_code": "__MODULE.MODULE_CODE"
     },
     "pose_localisation": {
@@ -109,6 +109,7 @@
         "Gîte chiro (arboricole en bois)",
         "Gîte chiro (fissuricole en bois)",
         "Gîte chiro (fissuricole en béton bois)",
+        "Martinet noir",
         "Mésange bleue",
         "Mésange charbonnière",
         "Moineau friquet",


### PR DESCRIPTION
Changed 'required' attribute for 'id_dataset' from false to true and added 'Martinet noir' to the list of options.

le jeu de données doit passer en obligatoire, car sinon sur l'application mobile cela fait planter la synchro au moment de téléversement des données. 